### PR TITLE
로컬에서 프론트엔드 서버 실행 시 백엔드 로컬 서버로 요청하게 하라

### DIFF
--- a/app-web/src/services/api.ts
+++ b/app-web/src/services/api.ts
@@ -8,7 +8,13 @@ import { SignUpFormData, User } from '../typings/auth';
 
 import { setTokenExpired } from '../redux/authSlice';
 
-const BASE_URL = 'https://api.codesoom-myseat.site';
+let BASE_URL = '';
+
+if (import.meta.env.MODE === 'development') {
+  BASE_URL = 'http://localhost:8080';
+} else {
+  BASE_URL = 'https://api.codesoom-myseat.site';
+}
 
 export const httpClient = axios.create({
   baseURL: BASE_URL,


### PR DESCRIPTION
기존에는 로컬에서 프론트엔드 서버를 실행했을 때 백엔드 실서버(https://api.codesoom-myseat.site) 로 요청을 보내고 있었습니다.
이 경우 로컬 테스트를 위한 데이터들이 실서버의 DB에 들어가서 오염됩니다.
따라서 로컬에서 dev 명령어로 프론트엔드 서버를 실행했을 때, 즉 development 모드로 동작할 때에는 BASE_URL이 localhost:8080으로 설정되도록 했습니다.

침고) https://vitejs-kr.github.io/guide/env-and-mode.html#modes