### PR TITLE
표시되는 문구를 좀더 자연스러운 표현으로 수정하라

### DIFF
--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -161,7 +161,7 @@ export default function ReservationsTable({
 
   const { mutate: cancelReservationMutate } = useMutation(cancelReservation, {
     onSuccess: () => {
-      alert('예약이 취소되셨습니다.');
+      alert('예약이 취소되었습니다.');
     },
     onError: (error: AxiosError) => {
       alert(error.response?.data);
@@ -231,7 +231,7 @@ export default function ReservationsTable({
       <StyledTable>
         <TableHead>
           <TableRow>
-            <StyledTableCell align="center">계획 일자</StyledTableCell>
+            <StyledTableCell align="center">방문 일자</StyledTableCell>
             <StyledTableCell align="center">계획 내용</StyledTableCell>
             <StyledTableCell align="center">회고 상세보기</StyledTableCell>
             <StyledTableCell align="center">계획 상세보기</StyledTableCell>

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -80,7 +80,7 @@ export default function Reservations() {
 
   const { mutate: reservationMutate, isLoading: reservationIsLoading } = useMutation(fetchReservation, {
     onSuccess: () => {
-      alert('예약이 신청되셨습니다.');
+      alert('예약이 완료되었습니다.');
       onClickToggleReservationsModal();
     },
     onError: (error: AxiosError) => {


### PR DESCRIPTION
'~되셨습니다'와 같이 부자연스러운 존칭이 사용된 문구를 '~되었습니다'로 수정했습니다.
그리고 기존에는 방문 예정 일자를 '계획 일자'로 표시하고 있었는데, '방문 일자'가 좀더 맞는 표현인 것 같아 수정했습니다.