### PR TITLE
회고 내용의 첫 줄이 온전히 보이도록 하라

### DIFF
--- a/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
+++ b/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
@@ -56,7 +56,7 @@ const TextBox = styled.div({
   marginBottom: '2rem',
 
   'p': {
-    margin: '0 0 1rem 0',
+    margin: '0.5rem 0 1rem 0',
   },
 });
 


### PR DESCRIPTION
기존에는 회고 상세 보기 시 아래 사진과 같이 첫 줄의 윗부분이 살짝 가려져서 보이고 있었습니다.

![스크린샷 2023-01-31 오후 9 17 46](https://user-images.githubusercontent.com/98736689/215758610-51e3da91-a7d3-4281-a5ed-3edc0d4a6ab2.png)

따라서 margin값을 조정하여 글자가 온전히 보이도록 수정했습니다.

![스크린샷 2023-01-31 오후 9 22 17](https://user-images.githubusercontent.com/98736689/215758648-445da9b1-b384-4233-8280-a3cd6d2629fd.png)
